### PR TITLE
Use a general link to the cljdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Native Clojure support for [Google Protocol Buffer](https://developers.google.co
 
 ## Documentation
 
-You can read the [SDK CLJ documentation](https://cljdoc.org/d/protojure/protojure/1.0.0)
+You can read the [SDK CLJ documentation](https://cljdoc.org/d/protojure/protojure)
 
 ## Usage
 


### PR DESCRIPTION
Pointing to the latest doc is probably better than to a specific version

Signed-off-by: Greg Haskins <greg@manetu.com>