### PR TITLE
Handle Clojure Collection EDN-esque response bodies

### DIFF
--- a/src/protojure/pedestal/core.clj
+++ b/src/protojure/pedestal/core.clj
@@ -176,7 +176,7 @@
     (write-streaming-data ch is)))
 (defmethod transmit-body :default
   [ch resp-body]
-  (write-direct-data ch resp-body))
+  (transmit-body ch (with-out-str (pr resp-body))))
 
 (defmulti ^:no-doc transmit-trailers
   "Handle transmitting the trailers based on the type"


### PR DESCRIPTION
Compare to: https://github.com/pedestal/pedestal/blob/master/samples/chain-providers/src/chain_providers/service.clj#L31

This change better ensures all cases degenerate to String response types, where the String bytes are then written to the outputstream.

Because we choose to handle all outputstreams asynchronously, we don't invoke the typical servlet path, e.g. for Jetty relying on https://www.eclipse.org/jetty/javadoc/current/org/eclipse/jetty/server/Handler.html#handle(java.lang.String,org.eclipse.jetty.server.Request,javax.servlet.http.HttpServletRequest,javax.servlet.http.HttpServletResponse) having an outputstream to directly write to.

Signed-off-by: Matt Rkiouak <mrkiouak@gmail.com>