### PR TITLE
Optimize server write path

### DIFF
--- a/src/protojure/pedestal/core.clj
+++ b/src/protojure/pedestal/core.clj
@@ -69,10 +69,10 @@
 
 (defn- -write
   [ch buf len]
-  (.awaitWritable ch)
   (let [bytes-written (.write ch buf)
         bytes-remain (- len bytes-written)]
     (when-not (zero? bytes-remain)
+      (.awaitWritable ch)
       (-write ch buf bytes-remain))))
 
 (defn- write-data


### PR DESCRIPTION
We only need to invoke (.awaitWritable) if we experience backpressure.

Signed-off-by: Greg Haskins <greg@manetu.com>