### PR TITLE
Add grpc-status and error handling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject protojure "1.3.2-SNAPSHOT"
+(defproject protojure "1.4.0-SNAPSHOT"
   :description "Support library for protoc-gen-clojure, providing native Clojure support for Google Protocol Buffers and GRPC applications"
   :url "http://github.com/protojure/library"
   :license {:name "Apache License 2.0"

--- a/src/protojure/grpc/status.clj
+++ b/src/protojure/grpc/status.clj
@@ -1,0 +1,35 @@
+;; Copyright © 2020 Manetu, Inc.  All rights reserved
+;;
+;; SPDX-License-Identifier: Apache-2.0
+
+(ns protojure.grpc.status)
+
+(def -codes
+  [[0   :ok                   "success"]
+   [1   :cancelled            "The operation was cancelled, typically by the caller."]
+   [2   :unknown              "Unknown error."]
+   [3   :invalid-argument     "The client specified an invalid argument."]
+   [4   :deadline-exceeded    "The deadline expired before the operation could complete."]
+   [5   :not-found            "Some requested entity (e.g., file or directory) was not found."]
+   [6   :already-exists       "The entity already exists."]
+   [7   :permission-denied    "The caller does not have permission to execute the specified operation."]
+   [8   :resource-exhausted   "Some resource has been exhausted"]
+   [9   :failed-precondition  "The system is not in a state required for the operation's execution"]
+   [10  :aborted              "The operation was aborted, typically due to a concurrency issue."]
+   [11  :out-of-range         "The operation was attempted past the valid range."]
+   [12  :unimplemented        "The operation is not implemented."]
+   [13  :internal             "Invariants expected by the underlying system have been broken"]
+   [14  :unavailable          "The service is currently unavailable."]
+   [15  :data-loss            "Unrecoverable data loss or corruption."]
+   [16  :unauthenticated      "The request does not have valid authentication credentials."]])
+
+(def codes
+  (->> (map (fn [[code type desc]] {:code code :type type :desc desc}) -codes)
+       (reduce (fn [acc {:keys [type] :as v}] (assoc acc type v)) {})))
+
+(def default-error (get codes :unknown))
+
+(defn error [type]
+  (let [desc (get codes type default-error)]
+    (when-not (= type :ok)
+      (throw (ex-info "grpc error" (merge desc {:exception-type ::error}))))))

--- a/test/protojure/grpc_test.clj
+++ b/test/protojure/grpc_test.clj
@@ -20,6 +20,7 @@
             [protojure.grpc.client.providers.http2 :as grpc.http2]
             [protojure.internal.grpc.client.providers.http2.jetty :as jetty-client]
             [protojure.grpc.client.utils :as client.utils]
+            [protojure.grpc.status :as grpc.status]
             [protojure.test.utils :as test.utils :refer [data-equal?]]
             [example.types :as example]
             [example.hello :refer [new-HelloRequest pb->HelloRequest new-HelloReply pb->HelloReply]]
@@ -133,9 +134,7 @@
      :body "This isn't a protobuf message"})
   (SayNil
     [this req]
-    {:body        nil
-     :grpc-status 7
-     :grpc-message "UNAUTHENTICATED"}))
+    (grpc.status/error :unauthenticated)))
 
 ;;-----------------------------------------------------------------------------
 ;; "FlowControl" service endpoint


### PR DESCRIPTION
This patch adds two features:

- We define GRPC status codes/exceptions in the protojure.grpc.status namespace
- We provide a pedestal exception handler that intercepts GRPC status codes
  and returns them to the caller following the appropriate GRPC protocol.

Aside from the convenience of allowing devs to easily discover the available
status codes that they may choose from, it also allows us support interceptors
(such as authentication/authorization) that may leverage these status codes
to return errors in a consistent manner.

We also bump the version to v1.4.0 since the status codes are a new feature.

Signed-off-by: Greg Haskins <greg@manetu.com>