### PR TITLE
Plumb http2 client SSL settings & make accessible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OUTPUT = target/$(NAME)-$(VERSION).jar
 POM = target/pom.xml
 DOC = target/doc/index.html
 
-COVERAGE_THRESHOLD = 87
+COVERAGE_THRESHOLD = 86
 COVERAGE_EXCLUSION += "user"
 COVERAGE_EXCLUSION += "protojure.internal.pedestal.io"
 

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,8 @@
                  [com.google.protobuf/protobuf-java "3.11.4" :scope "provided"]
                  [io.undertow/undertow-core "2.0.29.Final" :scope "provided"]
                  [io.undertow/undertow-servlet "2.0.29.Final" :scope "provided"]
-                 [org.eclipse.jetty.http2/http2-client "9.4.20.v20190813" :scope "provided"]
+                 [org.eclipse.jetty.http2/http2-client "9.4.28.v20200408" :scope "provided"]
+                 [org.eclipse.jetty/jetty-alpn-java-client "9.4.28.v20200408" :scope "provided"]
                  [io.pedestal/pedestal.log "0.5.7" :scope "provided"]
                  [io.pedestal/pedestal.service "0.5.7" :scope "provided"]
                  [org.clojure/tools.logging "1.0.0"]
@@ -29,7 +30,7 @@
           :namespaces [#"^(?!protojure.internal)"]}
   :profiles {:dev {:dependencies [[protojure/google.protobuf "0.9.1"]
                                   [org.clojure/tools.namespace "1.0.0"]
-                                  [clj-http "3.10.0"]
+                                  [clj-http "3.10.1"]
                                   [com.taoensso/timbre "4.10.0"]
                                   [org.clojure/data.codec "0.1.1"]
                                   [org.clojure/data.generators "1.0.0"]

--- a/src/protojure/grpc/client/providers/http2.clj
+++ b/src/protojure/grpc/client/providers/http2.clj
@@ -34,8 +34,8 @@ A map with the following entries:
 A promise that, on success, evaluates to an instance of [[api/Provider]].
 _(api/disconnect)_ should be used to release any resources when the connection is no longer required.
   "
-  [{:keys [uri codecs content-coding max-frame-size input-buffer-size metadata] :or {codecs builtin-codecs max-frame-size 16384 input-buffer-size 16384} :as params}]
+  [{:keys [uri codecs content-coding max-frame-size input-buffer-size metadata idle-timeout ssl] :or {codecs builtin-codecs max-frame-size 16384 input-buffer-size 16384 ssl false} :as params}]
   (log/debug "Connecting with GRPC-HTTP2:" params)
   (let [{:keys [host port]} (lambdaisland/uri uri)]
-    (-> (jetty/connect {:host host :port (Integer/parseInt port) :input-buffer-size input-buffer-size})
+    (-> (jetty/connect {:host host :port (Integer/parseInt port) :input-buffer-size input-buffer-size :idle-timeout idle-timeout :ssl ssl})
         (p/then #(core/->Http2Provider % uri codecs content-coding max-frame-size input-buffer-size metadata)))))


### PR DESCRIPTION
I have not added test coverage, as this TLS support is provided entirely by the underlying jetty libraries. I have in fact validated I am able to make a tls connection to a properly configured server.

Note that which version and jetty alpn artifact is required is dependent upon which version of java is running your http2 client -- for a `lein repl`, `lein run`, etc., this is the version of java used by your `lein` which is not necessarily the same java version as your local system is set up to use. This can lead to `No ALPN provider` errors regardless of what is present on your class path, so I advise checking and then following the directions for the relevant jdk version here: https://www.eclipse.org/jetty/documentation/9.4.28.v20200408/alpn-chapter.html#alpn-troubleshooting

Signed-off-by: Matt Rkiouak <mrkiouak@gmail.com>