### PR TITLE
Passing the idle-timeout parameter into the Jetty client

### DIFF
--- a/src/protojure/grpc/client/providers/http2.clj
+++ b/src/protojure/grpc/client/providers/http2.clj
@@ -28,13 +28,14 @@ A map with the following entries:
 | **content-coding**    | _String_ | nil     | The encoding to use on request data                                       |
 | **max-frame-size**    | _UInt32_ | 16384   | The maximum HTTP2 DATA frame size                                         |
 | **input-buffer-size** | _UInt32_ | 16M     | The input-buffer size                                                     |
+| **idle-timeout**      | _UInt64_ | 30000   | The idle timeout in milliseconds                                          |
 | **metadata**          | _map_    | n/a     | Optional [string string] tuples that will be submitted as attributes to the request, such as via HTTP headers for GRPC-HTTP2 |
 
 #### Return value
 A promise that, on success, evaluates to an instance of [[api/Provider]].
 _(api/disconnect)_ should be used to release any resources when the connection is no longer required.
   "
-  [{:keys [uri codecs content-coding max-frame-size input-buffer-size metadata idle-timeout ssl] :or {codecs builtin-codecs max-frame-size 16384 input-buffer-size 16384 ssl false} :as params}]
+  [{:keys [uri codecs content-coding max-frame-size input-buffer-size metadata idle-timeout ssl] :or {codecs builtin-codecs max-frame-size 16384 input-buffer-size 16384 idle-timeout 30000 ssl false} :as params}]
   (log/debug "Connecting with GRPC-HTTP2:" params)
   (let [{:keys [host port]} (lambdaisland/uri uri)]
     (-> (jetty/connect {:host host :port (Integer/parseInt port) :input-buffer-size input-buffer-size :idle-timeout idle-timeout :ssl ssl})

--- a/src/protojure/internal/grpc/client/providers/http2/jetty.clj
+++ b/src/protojure/internal/grpc/client/providers/http2/jetty.clj
@@ -167,17 +167,18 @@
 ;; Exposed API
 ;;------------------------------------------------------------------------------------
 
-(defn connect [{:keys [host port input-buffer-size idle-timeout ssl] :or {host "localhost" port 80 input-buffer-size 16384 ssl false} :as params}]
+(defn connect [{:keys [host port input-buffer-size idle-timeout ssl] :or {host "localhost" port 80 input-buffer-size 16384 idle-timeout 30000 ssl false} :as params}]
   (let [client (HTTP2Client.)
         address (InetSocketAddress. ^String host (int port))
         listener (ServerSessionListener$Adapter.)
         ssl-context-factory (when ssl (SslContextFactory$Client.))]
     (when ssl (.addBean client ssl-context-factory))
     (log/debug "Connecting with parameters: " params)
-    (.start client)
     (.setInputBufferSize client input-buffer-size)
     (.setInitialStreamRecvWindow client input-buffer-size)
     (.setInitialSessionRecvWindow client input-buffer-size)
+    (.setIdleTimeout client idle-timeout)
+    (.start client)
     (-> (jetty-promise
          (fn [p]
            (.connect client (when ssl ssl-context-factory) address listener p)))


### PR DESCRIPTION
Firstly, thank you very much for such a really useful framework backed by a solid codebase.

Looks like the upstream implementation does not yet pass on the idle timeout parameter down to the Jetty client layer. This PR fixes it by invoking the corresponding setter inside the Jetty client provider.
