### PR TITLE
Re-enable cloverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
     environment:
       LEIN_ROOT: nbd
       JVM_OPTS: -Xmx3200m
+      CLOVERAGE_VERSION: 1.1.2
     steps:
       - checkout
       - run:

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,7 @@ deep-scan: scan
 
 .PHONY: test
 test:
-	#$(LEIN) cloverage --fail-threshold $(COVERAGE_THRESHOLD) $(patsubst %,-e %, $(COVERAGE_EXCLUSION))
-	$(LEIN) test
+	$(LEIN) cloverage --fail-threshold $(COVERAGE_THRESHOLD) $(patsubst %,-e %, $(COVERAGE_EXCLUSION))
 
 doc: $(DOC)
 


### PR DESCRIPTION
We need to force the system to use v1.1.2 due to a bug in v1.1.3

Signed-off-by: Greg Haskins <greg@manetu.com>