### PR TITLE
Currently, lpm encoding requires non-nil & non-record map values for …

### DIFF
--- a/src/protojure/grpc/codec/lpm.clj
+++ b/src/protojure/grpc/codec/lpm.clj
@@ -234,7 +234,11 @@ The _max-frame-size_ option dictates how bytes are encoded on the _output_ chann
              (if-let [_msg (<! input)]
                (do
                  (log/trace "Encoding: " _msg)
-                 (let [msg (f _msg)]
+                 (let [msg (f (clojure.walk/postwalk #(cond
+                                                        (record? %) (into {} %)
+                                                        (nil? %) {}
+                                                        :else %)
+                                                     _msg))]
                    (if (some? compressor)
                      (encode-maybe-compressed msg compressor os)
                      (encode-uncompressed msg os))


### PR DESCRIPTION
…nested

messages. Ideally, the generated code should be updated to be more flexible.
However, this MR walks the pb and converts any non-matching values.

This MR likely has severe performance impact, and so we may opt
not to move forward with it.

Signed-off-by: Matt Rkiouak <mrkiouak@gmail.com>