### PR TITLE
Handle grpc-status in both HEADER and TRAILERS in grpc-http2 protocol

### DIFF
--- a/src/protojure/internal/grpc/client/providers/http2/jetty.clj
+++ b/src/protojure/internal/grpc/client/providers/http2/jetty.clj
@@ -97,9 +97,9 @@
               data (if (.isResponse metadata)
                      (let [status (.getStatus ^MetaData$Response metadata)
                            reason (.getReason ^MetaData$Response metadata)]
-                       (-> {:headers fields}
-                           (cond-> (some? status) (assoc :status status))
-                           (cond-> (some? reason) (assoc :reason reason))))
+                       (cond-> {:headers fields}
+                         (some? status) (assoc :status status)
+                         (some? reason) (assoc :reason reason)))
                      {:trailers fields})
               last? (.isEndStream ^HeadersFrame frame)]
           (stream-log :trace stream "Received HEADER-FRAME: " data " ENDFRAME=" last?)

--- a/test/protojure/grpc_test.clj
+++ b/test/protojure/grpc_test.clj
@@ -173,7 +173,12 @@
 
   (AllEmpty
     [_ request]
-    {:body {}}))
+    {:body {}})
+
+  (AsyncEmpty
+    [_ {:keys [grpc-out]}]
+    (async/close! grpc-out)
+    {:body grpc-out}))
 
 (defn- greeter-mock-routes [interceptors]
   (pedestal.routes/->tablesyntax {:rpc-metadata greeter/rpc-metadata
@@ -587,4 +592,11 @@
   (testing "Check that empty parameters are passed correctly"
     (let [client @(grpc.http2/connect {:uri (str "http://localhost:" (:port @test-env))})]
       @(test.client/AllEmpty client {})
+      (grpc/disconnect client))))
+
+(deftest test-grpc-async-empty
+  (testing "Check that an empty result-set is handled "
+    (let [output (async/chan 1)
+          client @(grpc.http2/connect {:uri (str "http://localhost:" (:port @test-env))})]
+      @(test.client/AsyncEmpty client {} output)
       (grpc/disconnect client))))

--- a/test/protojure/test/grpc/TestService/client.cljc
+++ b/test/protojure/test/grpc/TestService/client.cljc
@@ -16,66 +16,90 @@
 ;-----------------------------------------------------------------------------
 
 (defn CloseDetect
-  [client params reply]
+  ([client params reply] (CloseDetect client {} params reply))
+  ([client metadata params reply]
   (let [input (async/chan 1)
         desc {:service "protojure.test.grpc.TestService"
               :method  "CloseDetect"
               :input   {:f protojure.test.grpc/new-CloseDetectRequest :ch input}
-              :output  {:f com.google.protobuf/pb->Any :ch reply}}]
+              :output  {:f com.google.protobuf/pb->Any :ch reply}
+              :metadata metadata}]
     (-> (send-unary-params input params)
-        (p/then (fn [_] (grpc/invoke client desc))))))
+        (p/then (fn [_] (grpc/invoke client desc)))))))
 
 (defn FlowControl
-  [client params reply]
+  ([client params reply] (FlowControl client {} params reply))
+  ([client metadata params reply]
   (let [input (async/chan 1)
         desc {:service "protojure.test.grpc.TestService"
               :method  "FlowControl"
               :input   {:f protojure.test.grpc/new-FlowControlRequest :ch input}
-              :output  {:f protojure.test.grpc/pb->FlowControlPayload :ch reply}}]
+              :output  {:f protojure.test.grpc/pb->FlowControlPayload :ch reply}
+              :metadata metadata}]
     (-> (send-unary-params input params)
-        (p/then (fn [_] (grpc/invoke client desc))))))
+        (p/then (fn [_] (grpc/invoke client desc)))))))
 
 (defn Metadata
-  [client params]
+  ([client params] (Metadata client {} params))
+  ([client metadata params]
   (let [input (async/chan 1)
         output (async/chan 1)
         desc {:service "protojure.test.grpc.TestService"
               :method  "Metadata"
               :input   {:f com.google.protobuf/new-Empty :ch input}
-              :output  {:f protojure.test.grpc/pb->SimpleResponse :ch output}}]
+              :output  {:f protojure.test.grpc/pb->SimpleResponse :ch output}
+              :metadata metadata}]
     (-> (send-unary-params input params)
-        (p/then (fn [_] (invoke-unary client desc output))))))
+        (p/then (fn [_] (invoke-unary client desc output)))))))
 
 (defn ShouldThrow
-  [client params]
+  ([client params] (ShouldThrow client {} params))
+  ([client metadata params]
   (let [input (async/chan 1)
         output (async/chan 1)
         desc {:service "protojure.test.grpc.TestService"
               :method  "ShouldThrow"
               :input   {:f com.google.protobuf/new-Empty :ch input}
-              :output  {:f com.google.protobuf/pb->Empty :ch output}}]
+              :output  {:f com.google.protobuf/pb->Empty :ch output}
+              :metadata metadata}]
     (-> (send-unary-params input params)
-        (p/then (fn [_] (invoke-unary client desc output))))))
+        (p/then (fn [_] (invoke-unary client desc output)))))))
 
 (defn Async
-  [client params]
+  ([client params] (Async client {} params))
+  ([client metadata params]
   (let [input (async/chan 1)
         output (async/chan 1)
         desc {:service "protojure.test.grpc.TestService"
               :method  "Async"
               :input   {:f com.google.protobuf/new-Empty :ch input}
-              :output  {:f protojure.test.grpc/pb->SimpleResponse :ch output}}]
+              :output  {:f protojure.test.grpc/pb->SimpleResponse :ch output}
+              :metadata metadata}]
     (-> (send-unary-params input params)
-        (p/then (fn [_] (invoke-unary client desc output))))))
+        (p/then (fn [_] (invoke-unary client desc output)))))))
 
 (defn AllEmpty
-  [client params]
+  ([client params] (AllEmpty client {} params))
+  ([client metadata params]
   (let [input (async/chan 1)
         output (async/chan 1)
         desc {:service "protojure.test.grpc.TestService"
               :method  "AllEmpty"
               :input   {:f com.google.protobuf/new-Empty :ch input}
-              :output  {:f com.google.protobuf/pb->Empty :ch output}}]
+              :output  {:f com.google.protobuf/pb->Empty :ch output}
+              :metadata metadata}]
     (-> (send-unary-params input params)
-        (p/then (fn [_] (invoke-unary client desc output))))))
+        (p/then (fn [_] (invoke-unary client desc output)))))))
+
+(defn AsyncEmpty
+  ([client params reply] (AsyncEmpty client {} params reply))
+  ([client metadata params reply]
+  (let [input (async/chan 1)
+        desc {:service "protojure.test.grpc.TestService"
+              :method  "AsyncEmpty"
+              :input   {:f com.google.protobuf/new-Empty :ch input}
+              :output  {:f com.google.protobuf/pb->Empty :ch reply}
+              :metadata metadata}]
+    (-> (send-unary-params input params)
+        (p/then (fn [_] (grpc/invoke client desc)))))))
 

--- a/test/protojure/test/grpc/TestService/server.cljc
+++ b/test/protojure/test/grpc/TestService/server.cljc
@@ -16,7 +16,8 @@
   (Metadata [this param])
   (ShouldThrow [this param])
   (Async [this param])
-  (AllEmpty [this param]))
+  (AllEmpty [this param])
+  (AsyncEmpty [this param]))
 
 (defn- CloseDetect-dispatch
   [ctx request]
@@ -36,6 +37,9 @@
 (defn- AllEmpty-dispatch
   [ctx request]
   (AllEmpty ctx request))
+(defn- AsyncEmpty-dispatch
+  [ctx request]
+  (AsyncEmpty ctx request))
 
 (def ^:const rpc-metadata
   [{:pkg "protojure.test.grpc" :service "TestService" :method "CloseDetect" :method-fn CloseDetect-dispatch :server-streaming true :client-streaming false :input pb->CloseDetectRequest :output com.google.protobuf/new-Any}
@@ -43,4 +47,5 @@
    {:pkg "protojure.test.grpc" :service "TestService" :method "Metadata" :method-fn Metadata-dispatch :server-streaming false :client-streaming false :input com.google.protobuf/pb->Empty :output new-SimpleResponse}
    {:pkg "protojure.test.grpc" :service "TestService" :method "ShouldThrow" :method-fn ShouldThrow-dispatch :server-streaming false :client-streaming false :input com.google.protobuf/pb->Empty :output com.google.protobuf/new-Empty}
    {:pkg "protojure.test.grpc" :service "TestService" :method "Async" :method-fn Async-dispatch :server-streaming false :client-streaming false :input com.google.protobuf/pb->Empty :output new-SimpleResponse}
-   {:pkg "protojure.test.grpc" :service "TestService" :method "AllEmpty" :method-fn AllEmpty-dispatch :server-streaming false :client-streaming false :input com.google.protobuf/pb->Empty :output com.google.protobuf/new-Empty}])
+   {:pkg "protojure.test.grpc" :service "TestService" :method "AllEmpty" :method-fn AllEmpty-dispatch :server-streaming false :client-streaming false :input com.google.protobuf/pb->Empty :output com.google.protobuf/new-Empty}
+   {:pkg "protojure.test.grpc" :service "TestService" :method "AsyncEmpty" :method-fn AsyncEmpty-dispatch :server-streaming true :client-streaming false :input com.google.protobuf/pb->Empty :output com.google.protobuf/new-Empty}])

--- a/test/resources/grpctest.proto
+++ b/test/resources/grpctest.proto
@@ -30,4 +30,5 @@ service TestService {
     rpc ShouldThrow (google.protobuf.Empty) returns (google.protobuf.Empty);
     rpc Async (google.protobuf.Empty) returns (SimpleResponse);
     rpc AllEmpty(google.protobuf.Empty) returns (google.protobuf.Empty);
+    rpc AsyncEmpty(google.protobuf.Empty) returns (stream google.protobuf.Empty);
 }


### PR DESCRIPTION
It seems some golang servers may short-circuit the protocol when there
is no data to send, and simply set the grpc-status/message headers
in the initial HEADER message.  This patch allows protojure clients
to handle this situation.

Signed-off-by: Greg Haskins <greg@manetu.com>