### PR TITLE
Fix leak in unsubscribe

### DIFF
--- a/src/protojure/pedestal/core.clj
+++ b/src/protojure/pedestal/core.clj
@@ -239,10 +239,9 @@
     ch))
 
 (defn unsubscribe-close [connections ^HttpServerExchange exchange]
-  (let [conn (.getConnection exchange)]
-    (swap! connections
-           (fn [x]
-             (update x conn #(dissoc % exchange))))))
+  (let [conn (.getConnection exchange)
+        k (hash conn)]
+    (handle-disconnect connections k)))
 
 (declare handle-response)
 


### PR DESCRIPTION
The previous fix only partially addressed the per-exchange leak that
we were observing.  This should fix that logic such that the request
properly unsubscribes on completion.

There is still potentially another issue that remains related to an
obervation of an unexpectedly high number of registered connections,
which may mean that we are not properly detecting when a connection
is already listening, TBD.

Signed-off-by: Greg Haskins <greg@manetu.com>