### PR TITLE
Support multi-value headers

### DIFF
--- a/src/protojure/pedestal/core.clj
+++ b/src/protojure/pedestal/core.clj
@@ -314,8 +314,10 @@
 
   ;; Set Response Headers
   (let [ctx (.getResponseHeaders exchange)]
-    (doseq [[k v] headers]
-      (.put ctx (HttpString. ^String k) ^String v)))
+    (doseq [[^String k ^String v] headers]
+      (cond
+        (string? v) (.put ctx (HttpString. k) v)
+        (coll? v) (.putAll ctx (HttpString. k) v))))
 
   ;; Start asynchronous output
   (let [output-ch (open-output-channel exchange)]


### PR DESCRIPTION
Some headers, such as 'Set-Cookie' can be delivered as a collection of strings in the header map.
We currently crash if this happens.  This patch fixes the response handler to deal with multi-value
headers correctly.

Signed-off-by: Greg Haskins <greg@manetu.com>