### PR TITLE
Exclude non-protojure .class files from jar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,6 +26,7 @@
                  [lambdaisland/uri "1.4.70"]]
   :aot [protojure.internal.grpc.codec.io
         protojure.internal.pedestal.io]
+  :jar-exclusions [#"^(?!(protojure))"]
   :codox {:metadata {:doc/format :markdown}
           :namespaces [#"^(?!protojure.internal)"]}
   :profiles {:dev {:dependencies [[protojure/google.protobuf "0.9.1"]


### PR DESCRIPTION
Due to how the clojure compiler AOT behaves,
the packaged lib jar must exclude non-project
namespaces in order to prevent bundling
dependency .class files in the protojure jar

Signed-off-by: Matthew Rkiouak <mrkiouak@gmail.com>