### PR TITLE
[io] Eliminate AOT with native .java classes/interfaces

### DIFF
--- a/modules/grpc-server/src/protojure/pedestal/core.clj
+++ b/modules/grpc-server/src/protojure/pedestal/core.clj
@@ -14,7 +14,8 @@
             [clojure.core.async :refer [go-loop <!! <! go chan >!! >! close! timeout poll! promise-chan]]
             [promesa.core :as p]
             [clojure.java.io :as io]
-            [protojure.pedestal.ssl :as ssl])
+            [protojure.pedestal.ssl :as ssl]
+            [protojure.internal.io :as pio])
   (:import (io.undertow.server HttpHandler
                                HttpServerExchange
                                ServerConnection
@@ -289,7 +290,7 @@
   chain asynchronously"
   [^ThreadPoolExecutor pool interceptors connections ^HttpServerExchange exchange]
   (let [input-ch         (chan 16384) ;; TODO this allocation likely needs adaptive tuning
-        input-stream     (protojure.internal.io.InputStream. {:ch input-ch})
+        input-stream     (pio/new-inputstream {:ch input-ch})
         input-status     (open-input-channel exchange input-ch)
         request          {:query-string     (.getQueryString exchange)
                           :request-method   (keyword (string/lower-case (.toString (.getRequestMethod exchange))))

--- a/modules/io/project.clj
+++ b/modules/io/project.clj
@@ -14,4 +14,4 @@
                    :inherit [:managed-dependencies :javac-options]}
   :dependencies [[org.clojure/clojure]
                  [org.clojure/core.async]]
-  :aot [protojure.internal.io])
+  :java-source-paths ["src"])

--- a/modules/io/src/protojure/internal/io/AsyncInputStream.java
+++ b/modules/io/src/protojure/internal/io/AsyncInputStream.java
@@ -1,0 +1,10 @@
+package protojure.internal.io;
+
+import java.io.IOException;
+
+public interface AsyncInputStream {
+    public int available () throws IOException;
+    public int read_int() throws IOException;
+    public int read_bytes(byte[] b) throws IOException;
+    public int read_offset(byte[] b, int offset, int len) throws IOException;
+}

--- a/modules/io/src/protojure/internal/io/AsyncOutputStream.java
+++ b/modules/io/src/protojure/internal/io/AsyncOutputStream.java
@@ -1,0 +1,11 @@
+package protojure.internal.io;
+
+import java.io.IOException;
+
+public interface AsyncOutputStream {
+    public void flush() throws IOException;
+    public void close() throws IOException;
+    public void write_int(int b) throws IOException;
+    public void write_bytes(byte[] b) throws IOException;
+    public void write_offset(byte[] b, int offset, int len) throws IOException;
+}

--- a/modules/io/src/protojure/internal/io/ProxyInputStream.java
+++ b/modules/io/src/protojure/internal/io/ProxyInputStream.java
@@ -1,0 +1,33 @@
+package protojure.internal.io;
+
+import java.io.IOException;
+
+// adds a Proxy between java.io.InputStream and a core.async-based backend, by way of a reified AsyncInputStream
+public class ProxyInputStream extends java.io.InputStream {
+
+    public ProxyInputStream(AsyncInputStream backend) {
+        m_backend = backend;
+    }
+
+    private final AsyncInputStream m_backend;
+
+    @Override
+    public int available () throws IOException {
+        return m_backend.available();
+    }
+
+    @Override
+    public int read() throws IOException {
+        return m_backend.read_int();
+    }
+
+    @Override
+    public int read(byte[] bytes) throws IOException {
+        return m_backend.read_bytes(bytes);
+    }
+
+    @Override
+    public int read(byte[] bytes, int offset, int len) throws IOException {
+        return m_backend.read_offset(bytes, offset, len);
+    }
+}

--- a/modules/io/src/protojure/internal/io/ProxyOutputStream.java
+++ b/modules/io/src/protojure/internal/io/ProxyOutputStream.java
@@ -1,0 +1,38 @@
+package protojure.internal.io;
+
+import java.io.IOException;
+
+// adds a Proxy between java.io.OutputStream and a core.async-based backend, by way of a reified AsyncOutputStream
+public class ProxyOutputStream extends java.io.OutputStream {
+
+    public ProxyOutputStream(AsyncOutputStream backend) {
+        m_backend = backend;
+    }
+
+    private final AsyncOutputStream m_backend;
+
+    @Override
+    public void flush() throws IOException {
+        m_backend.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        m_backend.close();
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        m_backend.write_int(b);
+    }
+
+    @Override
+    public void write(byte[] bytes) throws IOException {
+        m_backend.write_bytes(bytes);
+    }
+
+    @Override
+    public void write(byte[] bytes, int offset, int len) throws IOException {
+        m_backend.write_offset(bytes, offset, len);
+    }
+}

--- a/test/project.clj
+++ b/test/project.clj
@@ -37,7 +37,7 @@
                                   [crypto-random "1.2.1"]]
                    :resource-paths ["test/resources"]}}
   :source-paths ["../modules/io/src" "../modules/core/src" "../modules/grpc-client/src" "../modules/grpc-server/src"]
-  :aot [protojure.internal.io]
+  :java-source-paths ["../modules/io/src"]
   :cloverage {:runner :eftest
               :runner-opts {:multithread? false
                             :fail-fast? true}

--- a/test/test/protojure/pedestal_test.clj
+++ b/test/test/protojure/pedestal_test.clj
@@ -10,6 +10,7 @@
             [io.pedestal.http.body-params :as body-params]
             [protojure.pedestal.core :as protojure.pedestal]
             [protojure.test.utils :as test.utils]
+            [protojure.internal.io :as pio]
             [clj-http.client :as client]
             [clojure.java.io :as io])
   (:import [java.nio ByteBuffer]))
@@ -159,7 +160,7 @@
   (testing "Check that bytes entered to channel are properly read from InputStream"
     (let [test-string "Hello"
           test-channel (async/chan 8096)
-          in-stream (protojure.internal.io.InputStream. {:ch test-channel})
+          in-stream (pio/new-inputstream {:ch test-channel})
           buff (byte-array 5)]
       (>!! test-channel (ByteBuffer/wrap (.getBytes test-string)))
       (async/close! test-channel)


### PR DESCRIPTION
I thought the split would be enough to solve the AOT w/gen-class issue, but after
further investigation, it turns out that it is not becaues we were still bundling
clojure and core.async .class files.  This patch eliminates the problem entirely
by taking a different approach with native java.  This was found to be neessary
because of the weirdness of java.io's use of multi-arity overloading that precluded
non gen-class solutions such as clojure.core/proxy.

Signed-off-by: Greg Haskins <greg@manetu.com>