### PR TITLE
gRPC client: add 'te' header

### DIFF
--- a/modules/grpc-client/src/protojure/internal/grpc/client/providers/http2/core.clj
+++ b/modules/grpc-client/src/protojure/internal/grpc/client/providers/http2/core.clj
@@ -35,7 +35,8 @@
   (log/trace (str "Invoking GRPC \""  service "/" method "\""))
   (let [hdrs (-> {"content-type" "application/grpc+proto"
                   "grpc-encoding" (or content-coding "identity")
-                  "grpc-accept-encoding" (codecs-to-accept codecs)}
+                  "grpc-accept-encoding" (codecs-to-accept codecs)
+                  "te" "trailers"}
                  (merge conn-metadata metadata))
         url (str uri "/" service "/" method)]
     (jetty/send-request context {:method    "POST"


### PR DESCRIPTION
The "TE" header is
[required](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) on client requests by the gRPC specification. Requests without it are rejected by grpc-c (reference implementation) servers. The TE header value is set to the constant string "trailers".

See also:
https://mailman.nginx.org/pipermail/nginx-devel/2018-March/010946.html