### PR TITLE
test: add slf4j bindings to facilitate Jetty debugging

### DIFF
--- a/test/dev-resources/log4j2.xml
+++ b/test/dev-resources/log4j2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="warn">
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%p %d %c: %m%n%throwable" />
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="warn">
+      <AppenderRef ref="console" />
+    </Root>
+    <!--
+    <Logger name="org.eclipse" level="trace" additivity="false">
+      <AppenderRef ref="console" />
+    </Logger>
+    -->
+  </Loggers>
+</Configuration>

--- a/test/project.clj
+++ b/test/project.clj
@@ -26,6 +26,8 @@
                                   [org.eclipse.jetty/jetty-alpn-java-client]
                                   [lambdaisland/uri]
                                   [org.clojure/tools.logging]
+                                  [org.apache.logging.log4j/log4j-core "2.17.1"]
+                                  [org.apache.logging.log4j/log4j-slf4j-impl "2.17.1"]
                                   [org.clojure/tools.namespace "1.2.0"]
                                   [clj-http "3.12.3"]
                                   [com.taoensso/timbre "5.1.2"]


### PR DESCRIPTION
Facilitates debugging of #121 and possibly future issues. Uncomment the section in log4j2.xml to lower the log level for specific packages. This does not change the timbre configuration to route through log4j.