### PR TITLE
Add metadata functions

### DIFF
--- a/modules/grpc-client/src/protojure/grpc/client/providers/http2.clj
+++ b/modules/grpc-client/src/protojure/grpc/client/providers/http2.clj
@@ -22,13 +22,13 @@ Connects the client to a [GRPC-HTTP2](https://github.com/grpc/grpc/blob/master/d
 A map with the following entries:
 
 | Value                 | Type     | Default | Description                                                               |
-|-----------------------|----------|-------------------------------------------------------------------------------------|
-| **uri**               | _String_ | n/a     | The URI of the GRPC server                                                |
-| **codecs**            | _map_    | [[protojure.grpc.codec.core/builtin-codecs]] | Optional custom codecs               |
-| **content-coding**    | _String_ | nil     | The encoding to use on request data                                       |
-| **max-frame-size**    | _UInt32_ | 16KB    | The maximum HTTP2 DATA frame size                                         |
-| **input-buffer-size** | _UInt32_ | 1MB     | The input-buffer size                                                     |
-| **metadata**          | _map_    | n/a     | Optional [string string] tuples that will be submitted as attributes to the request, such as via HTTP headers for GRPC-HTTP2 |
+|-----------------------|---------------|-------------------------------------------------------------------------------------|
+| **uri**               | _String_      | n/a     | The URI of the GRPC server                                                |
+| **codecs**            | _map_         | [[protojure.grpc.codec.core/builtin-codecs]] | Optional custom codecs               |
+| **content-coding**    | _String_      | nil     | The encoding to use on request data                                       |
+| **max-frame-size**    | _UInt32_      | 16KB    | The maximum HTTP2 DATA frame size                                         |
+| **input-buffer-size** | _UInt32_      | 1MB     | The input-buffer size                                                     |
+| **metadata**          | _map_ or _fn_ | n/a     | Optional [string string] tuples as a map, or a 0-arity fn that returns same that will be submitted as attributes to the request, such as via HTTP headers for GRPC-HTTP2 |
 
 #### Return value
 A promise that, on success, evaluates to an instance of [[api/Provider]].

--- a/modules/grpc-client/src/protojure/internal/grpc/client/providers/http2/core.clj
+++ b/modules/grpc-client/src/protojure/internal/grpc/client/providers/http2/core.clj
@@ -29,6 +29,12 @@
 (defn- codecs-to-accept [codecs]
   (clojure.string/join "," (cons "identity" (keys codecs))))
 
+(defn- compute-metadata
+  [metadata]
+  (if (fn? metadata)
+    (metadata)
+    metadata))
+
 (defn- send-request
   "Sends an HTTP2 based POST request that adheres to the GRPC-HTTP2 specification"
   [context uri codecs content-coding conn-metadata {:keys [metadata service method options] :as params} input-ch meta-ch output-ch]
@@ -37,7 +43,7 @@
                   "grpc-encoding" (or content-coding "identity")
                   "grpc-accept-encoding" (codecs-to-accept codecs)
                   "te" "trailers"}
-                 (merge conn-metadata metadata))
+                 (merge (compute-metadata conn-metadata) metadata))
         url (str uri "/" service "/" method)]
     (jetty/send-request context {:method    "POST"
                                  :url       url

--- a/test/test/protojure/grpc_test.clj
+++ b/test/test/protojure/grpc_test.clj
@@ -668,8 +668,12 @@
                    @(test.client/Async client {:id input}))))))
 
 (deftest test-grpc-metadata
-  (testing "Check that connection-metadata is sent to the server"
+  (testing "Check that static connection-metadata is sent to the server"
     (let [client @(grpc.http2/connect {:uri (str "http://localhost:" (:port @test-env)) :metadata {"authorization" "Magic"}})]
+      (is (-> @(test.client/Metadata client {}) :msg (= "Hello, Magic")))
+      (grpc/disconnect client)))
+  (testing "Check that dynamic connection-metadata is sent to the server"
+    (let [client @(grpc.http2/connect {:uri (str "http://localhost:" (:port @test-env)) :metadata (constantly {"authorization" "Magic"})})]
       (is (-> @(test.client/Metadata client {}) :msg (= "Hello, Magic")))
       (grpc/disconnect client))))
 


### PR DESCRIPTION
The GRPC client interface allows an optional map of "metadata" name/value pairs, sent as HTTP headers, to be
specified.  This is useful for things like authorization, allowing the caller to set access tokens etc.

There are two types of metadata: per-connection and per-call.  Currently, both of these are simple maps that
are merged together for any given request.

The problem with per-connection metadata is that connections may be held open for long periods of time, and this
has the potential to allow information contained in the per-connection metadata to go stale.  For example,
a JSON Web Token set in an "Authorization" header may expire on a shorter horizon than the connection.

This patch enhances this by allowing the per-connection metadata to be specified as an optional 0-arity
fn that returns a metadata map.  This way, we remain backwards compatible with existing applications that
use the static per-connection metadata, while allowing new clients to provide a means to refresh the
metadata on whatever interval suits their needs.

For instance, a metadata function could be written such that it handles JWT acquisition, caching, and just-in-time
token refresh transparently to protojure.

Signed-off-by: Greg Haskins <greg@manetu.com>