### PR TITLE
Fix warning about overriding `take` function

### DIFF
--- a/modules/grpc-server/src/protojure/pedestal/interceptors/grpc.clj
+++ b/modules/grpc-server/src/protojure/pedestal/interceptors/grpc.clj
@@ -66,7 +66,7 @@
         (set-params context params)                         ;; materialize unary params opportunistically,  if available
         (go (set-params context (<! input-ch)))))))         ;; else, defer context until unary params materialize
 
-(defn- take [ch]
+(defn- take-promise [ch]
   (p/create
    (fn [resolve reject]
      (async/take! ch resolve))))
@@ -84,7 +84,7 @@
 (defn- prepare-trailers [{:keys [trailers] :as response}]
   (let [ch (async/promise-chan)]
     [ch (fn [_] (-> (if (some? trailers)
-                      (take trailers)
+                      (take-promise trailers)
                       response)
                     (p/then ->trailers)
                     (p/then (partial put ch))))]))


### PR DESCRIPTION
WARNING: take already refers to: #'clojure.core/take in namespace: protojure.pedestal.interceptors.grpc, being replaced by: #'protojure.pedestal.interceptors.grpc/take

Signed-off-by: Ryan Sundberg <ryan@arctype.co>