### PR TITLE
disconnect: Return a promise that blocks until the connection closes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,4 @@
 - George Lindsell <glindsell@statestreet.com>
 - Sean Harrap <sean.harrap@gmail.com>
 - Enzzo Cavallo <souenzzo@gmail.com>
+- Ryan Sundberg <ryan@arctype.co>

--- a/test/test/protojure/grpc_test.clj
+++ b/test/test/protojure/grpc_test.clj
@@ -280,7 +280,7 @@
     (is (= status 0))))
 
 (defn- scaletest-disconnect [{:keys [client]}]
-  (grpc/disconnect client))
+  @(grpc/disconnect client))
 
 ;;-----------------------------------------------------------------------------
 ;; Streaming Scaletest
@@ -440,8 +440,8 @@
       (swap! test-env assoc :port port :server server :client client :grpc-client grpc-client))))
 
 (defn destroy-service []
-  (swap! test-env update :grpc-client grpc/disconnect)
-  (swap! test-env update :client jetty-client/disconnect)
+  (swap! test-env update :grpc-client #(deref (grpc/disconnect %)))
+  (swap! test-env update :client #(deref (jetty-client/disconnect %)))
   (swap! test-env update :server pedestal/stop))
 
 (defn wrap-service [test-fn]


### PR DESCRIPTION
### Background
I discovered some race conditions in unit tests I was writing, spinning up servers and clients, making rpcs, and tearing them back down. It turns out that the `disconnect` method here was not blocking until the connection closes. This patch makes a small breaking change to the API, so `disconnect` returns a promise of the context map instead of just the context map. The promise resolves when the HTTP2Client fully shuts down.

Since this is a public API change, even if maybe nobody will notice it, we can either bump the minor version number, or let me know if you want me to rework it into a backwards compatible change (perhaps with a config option to enable returning a promise). Without changing the interface, we can just sync on the promise internally before returning the context. However I think it would be beneficial to return a promise from `disconnect` to be consistent with the `connect` interface. 


### Commit Description
The `.stop` method on the Jetty HTTP2Client is non-blocking. The client
must use an event listener to synchronize the state until the client
completely shuts down.

This changes the interface of the public `(disconnect)` API to return
a promise instead, which will resolve when the HTTP2Client finishes
stopping (or throws on an error).

Signed-off-by: Ryan Sundberg <ryan@arctype.co>