### PR TITLE
Add "identity" to accepted encoding

### DIFF
--- a/modules/grpc-server/src/protojure/pedestal/interceptors/grpc.clj
+++ b/modules/grpc-server/src/protojure/pedestal/interceptors/grpc.clj
@@ -17,7 +17,7 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^{:const true :no-doc true} supported-encodings (set (keys protojure.grpc.codec.compression/builtin-codecs)))
+(def ^{:const true :no-doc true} supported-encodings (-> protojure.grpc.codec.compression/builtin-codecs (keys) (conj "identity") (set)))
 
 (defn- determine-output-encoding
   [accepted-encodings]


### PR DESCRIPTION
I noticed that the bidi timings were asymetrical: uploads were much
faster than downloads.  I was curious as to why, and investigating
I found out that the application of encoding was the culprit:

The test was using identity for upload and gzip for download.  Since the
tests run localhost where there is not an appreciable bandwidth benefit to
compression, the download case was disadvantaged.

The root cause is that the server->client path was only considering the following

```
protojure.pedestal.interceptors.grpc/supported-encodings
=> #{"snappy" "gzip" "deflate"}
```

except under cases where there was incongruence, and then and only then
would it fall back to an identity encoding.  This isn't really correct,
so we update the system to add "identity" to the set of supported encodings,
giving the caller more control.  As always, we will select the first
encoding that we mutally support, but now we also allow identity encodings
to be part of the calculus.

Signed-off-by: Greg Haskins <greg@manetu.com>