### PR TITLE
Automatically determine ssl parameter when uri has https scheme (#134)

### DIFF
--- a/modules/grpc-client/src/protojure/grpc/client/providers/http2.clj
+++ b/modules/grpc-client/src/protojure/grpc/client/providers/http2.clj
@@ -34,8 +34,8 @@ A map with the following entries:
 A promise that, on success, evaluates to an instance of [[api/Provider]].
 _(api/disconnect)_ should be used to release any resources when the connection is no longer required.
   "
-  [{:keys [uri codecs content-coding max-frame-size input-buffer-size metadata idle-timeout ssl] :or {codecs builtin-codecs max-frame-size 16384 input-buffer-size jetty/default-input-buffer ssl false} :as params}]
+  [{:keys [uri codecs content-coding max-frame-size input-buffer-size metadata idle-timeout ssl] :or {codecs builtin-codecs max-frame-size 16384 input-buffer-size jetty/default-input-buffer} :as params}]
   (log/debug "Connecting with GRPC-HTTP2:" params)
   (let [{:keys [host port]} (lambdaisland/uri uri)]
-    (-> (jetty/connect {:host host :port (Integer/parseInt port) :input-buffer-size input-buffer-size :idle-timeout idle-timeout :ssl ssl})
+    (-> (jetty/connect {:host host :port (Integer/parseInt port) :input-buffer-size input-buffer-size :idle-timeout idle-timeout :ssl (or ssl (.startsWith (.toLowerCase uri) "https://"))})
         (p/then #(core/->Http2Provider % uri codecs content-coding max-frame-size input-buffer-size metadata)))))

--- a/test/project.clj
+++ b/test/project.clj
@@ -36,6 +36,7 @@
                                   [danlentz/clj-uuid "0.1.9"]
                                   [eftest "0.5.9"]
                                   [criterium "0.4.6"]
+                                  [circleci/bond "0.6.0"]
                                   [crypto-random "1.2.1"]]
                    :resource-paths ["test/resources"]}}
   :source-paths ["../modules/io/src" "../modules/core/src" "../modules/grpc-client/src" "../modules/grpc-server/src"]


### PR DESCRIPTION
Convenience enhancement so caller doesn't have to specify `:uri` for common situations.  If uri starts with `https://` scheme, then use ssl as true. Still respect provided `:ssl` param if present.

Added tests for this situation that use `circleci.bond` for this purpose, since it's difficult to setup an SSL test; this verifies the expected connect call is made.