### PR TITLE
Update deps

### DIFF
--- a/modules/core/project.clj
+++ b/modules/core/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.protojure/core "2.4.2-SNAPSHOT"
+(defproject io.github.protojure/core "2.5.0-SNAPSHOT"
   :description "Core protobuf and GRPC utilities for protojure"
   :url "http://github.com/protojure/lib"
   :license {:name "Apache License 2.0"

--- a/modules/grpc-client/project.clj
+++ b/modules/grpc-client/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.protojure/grpc-client "2.4.2-SNAPSHOT"
+(defproject io.github.protojure/grpc-client "2.5.0-SNAPSHOT"
   :description "GRPC client library for protoc-gen-clojure"
   :url "http://github.com/protojure/lib"
   :license {:name "Apache License 2.0"

--- a/modules/grpc-client/src/protojure/internal/grpc/client/providers/http2/jetty.clj
+++ b/modules/grpc-client/src/protojure/internal/grpc/client/providers/http2/jetty.clj
@@ -207,7 +207,7 @@
                     (fn [resolve reject]
                       (.stop client)                       ;; run (.stop) in a different thread, because p/catch will be called from .connect -> reject
                       (reject e))
-                    p.exec/default-executor))))))
+                    p.exec/*default-executor*))))))
 
 (defn send-request
   [{:keys [^Session session] :as context}

--- a/modules/grpc-server/project.clj
+++ b/modules/grpc-server/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.protojure/grpc-server "2.4.2-SNAPSHOT"
+(defproject io.github.protojure/grpc-server "2.5.0-SNAPSHOT"
   :description "GRPC server library for protoc-gen-clojure"
   :url "http://github.com/protojure/lib"
   :license {:name "Apache License 2.0"

--- a/modules/io/project.clj
+++ b/modules/io/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.protojure/io "2.4.2-SNAPSHOT"
+(defproject io.github.protojure/io "2.5.0-SNAPSHOT"
   :description "IO library to support io.github.protojure/core"
   :url "http://github.com/protojure/lib"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def protojure-version "2.4.2-SNAPSHOT")
+(def protojure-version "2.5.0-SNAPSHOT")
 
 (defproject io.github.protojure/lib-suite "0.0.1"
   :description "Support libraries for protoc-gen-clojure, providing native Clojure support for Google Protocol Buffers and GRPC applications"
@@ -15,9 +15,9 @@
                          [com.google.protobuf/protobuf-java "3.21.7"]
                          [org.apache.commons/commons-compress "1.21"]
                          [commons-io/commons-io "2.11.0"]
-                         [funcool/promesa "9.0.462"]
-                         [io.undertow/undertow-core "2.2.19.Final"]
-                         [io.undertow/undertow-servlet "2.2.19.Final"]
+                         [funcool/promesa "9.0.477"]
+                         [io.undertow/undertow-core "2.2.20.Final"]
+                         [io.undertow/undertow-servlet "2.2.20.Final"]
                          [io.pedestal/pedestal.log "0.5.10"]
                          [io.pedestal/pedestal.service "0.5.10"]
                          [org.eclipse.jetty.http2/http2-client "11.0.12"]

--- a/test/project.clj
+++ b/test/project.clj
@@ -5,10 +5,10 @@
             :url "https://www.apache.org/licenses/LICENSE-2.0"
             :year 2022
             :key "apache-2.0"}
-  :plugins [[lein-cljfmt "0.8.0"]
+  :plugins [[lein-cljfmt "0.9.0"]
             [lein-set-version "0.4.1"]
-            [lein-cloverage "1.2.2"]
-            [lein-parent "0.3.8"]]
+            [lein-cloverage "1.2.3"]
+            [lein-parent "0.3.9"]]
   :parent-project {:path "../project.clj"
                    :inherit [:managed-dependencies :javac-options]}
   :profiles {:dev {:dependencies   [[org.clojure/clojure]
@@ -30,9 +30,9 @@
                                     [clj-http "3.12.3"]
                                     [com.taoensso/timbre "5.2.1"]
                                     [com.fzakaria/slf4j-timbre "0.3.21"]
-                                    [org.slf4j/jul-to-slf4j "1.7.36"]
-                                    [org.slf4j/jcl-over-slf4j "1.7.36"]
-                                    [org.slf4j/log4j-over-slf4j "1.7.36"]
+                                    [org.slf4j/jul-to-slf4j "2.0.3"]
+                                    [org.slf4j/jcl-over-slf4j "2.0.3"]
+                                    [org.slf4j/log4j-over-slf4j "2.0.3"]
                                     [org.clojure/data.codec "0.1.1"]
                                     [org.clojure/data.generators "1.0.0"]
                                     [danlentz/clj-uuid "0.1.9"]


### PR DESCRIPTION
There was a breaking change in promesa default-executor, so we bump the minor version to 2.5 to communicate this change to consumers.

Signed-off-by: Greg Haskins <greg@manetu.com>