### PR TITLE
Add support for :authorizer option in routes/->tablesyntax

### DIFF
--- a/test/test/protojure/test/grpc.cljc
+++ b/test/test/protojure/test/grpc.cljc
@@ -40,6 +40,9 @@
 (declare cis->BigPayload)
 (declare ecis->BigPayload)
 (declare new-BigPayload)
+(declare cis->AuthzTestRequest)
+(declare ecis->AuthzTestRequest)
+(declare new-AuthzTestRequest)
 
 ;;----------------------------------------------------------------------------------
 ;;----------------------------------------------------------------------------------
@@ -71,6 +74,29 @@
   ([tag value os] (write-BigPayload-Mode tag {:optimize false} value os))
   ([tag options value os]
    (serdes.core/write-Enum tag options (get-BigPayload-Mode value) os)))
+
+;-----------------------------------------------------------------------------
+; AuthzTestRequest-Type
+;-----------------------------------------------------------------------------
+(def AuthzTestRequest-Type-default :request-good)
+
+(def AuthzTestRequest-Type-val2label {0 :request-good
+                                      1 :request-bad})
+
+(def AuthzTestRequest-Type-label2val (set/map-invert AuthzTestRequest-Type-val2label))
+
+(defn cis->AuthzTestRequest-Type [is]
+  (let [val (serdes.core/cis->Enum is)]
+    (get AuthzTestRequest-Type-val2label val val)))
+
+(defn- get-AuthzTestRequest-Type [value]
+  {:pre [(or (int? value) (contains? AuthzTestRequest-Type-label2val value))]}
+  (get AuthzTestRequest-Type-label2val value value))
+
+(defn write-AuthzTestRequest-Type
+  ([tag value os] (write-AuthzTestRequest-Type tag {:optimize false} value os))
+  ([tag options value os]
+   (serdes.core/write-Enum tag options (get-AuthzTestRequest-Type value) os)))
 
 ;;----------------------------------------------------------------------------------
 ;;----------------------------------------------------------------------------------
@@ -425,4 +451,52 @@
   (cis->BigPayload (serdes.stream/new-cis input)))
 
 (def ^:protojure.protobuf.any/record BigPayload-meta {:type "protojure.test.grpc.BigPayload" :decoder pb->BigPayload})
+
+;-----------------------------------------------------------------------------
+; AuthzTestRequest
+;-----------------------------------------------------------------------------
+(defrecord AuthzTestRequest-record [type]
+  pb/Writer
+  (serialize [this os]
+    (write-AuthzTestRequest-Type 1  {:optimize true} (:type this) os))
+  pb/TypeReflection
+  (gettype [this]
+    "protojure.test.grpc.AuthzTestRequest"))
+
+(s/def :protojure.test.grpc.AuthzTestRequest/type (s/or :keyword keyword? :int int?))
+(s/def ::AuthzTestRequest-spec (s/keys :opt-un [:protojure.test.grpc.AuthzTestRequest/type]))
+(def AuthzTestRequest-defaults {:type AuthzTestRequest-Type-default})
+
+(defn cis->AuthzTestRequest
+  "CodedInputStream to AuthzTestRequest"
+  [is]
+  (->> (tag-map AuthzTestRequest-defaults
+                (fn [tag index]
+                  (case index
+                    1 [:type (cis->AuthzTestRequest-Type is)]
+
+                    [index (serdes.core/cis->undefined tag is)]))
+                is)
+       (map->AuthzTestRequest-record)))
+
+(defn ecis->AuthzTestRequest
+  "Embedded CodedInputStream to AuthzTestRequest"
+  [is]
+  (serdes.core/cis->embedded cis->AuthzTestRequest is))
+
+(defn new-AuthzTestRequest
+  "Creates a new instance from a map, similar to map->AuthzTestRequest except that
+  it properly accounts for nested messages, when applicable.
+  "
+  [init]
+  {:pre [(if (s/valid? ::AuthzTestRequest-spec init) true (throw (ex-info "Invalid input" (s/explain-data ::AuthzTestRequest-spec init))))]}
+  (-> (merge AuthzTestRequest-defaults init)
+      (map->AuthzTestRequest-record)))
+
+(defn pb->AuthzTestRequest
+  "Protobuf to AuthzTestRequest"
+  [input]
+  (cis->AuthzTestRequest (serdes.stream/new-cis input)))
+
+(def ^:protojure.protobuf.any/record AuthzTestRequest-meta {:type "protojure.test.grpc.AuthzTestRequest" :decoder pb->AuthzTestRequest})
 

--- a/test/test/protojure/test/grpc/TestService/client.cljc
+++ b/test/test/protojure/test/grpc/TestService/client.cljc
@@ -164,6 +164,19 @@
      (-> (send-unary-params input params)
          (p/then (fn [_] (grpc/invoke client desc)))))))
 
+(defn AuthzTest
+  ([client params] (AuthzTest client {} params))
+  ([client metadata params]
+   (let [input (async/chan 1)
+         output (async/chan 1)
+         desc {:service "protojure.test.grpc.TestService"
+               :method  "AuthzTest"
+               :input   {:f protojure.test.grpc/new-AuthzTestRequest :ch input}
+               :output  {:f com.google.protobuf/pb->Empty :ch output}
+               :metadata metadata}]
+     (-> (send-unary-params input params)
+         (p/then (fn [_] (invoke-unary client desc output)))))))
+
 (defn ShouldThrow
   ([client params] (ShouldThrow client {} params))
   ([client metadata params]

--- a/test/test/protojure/test/grpc/TestService/server.cljc
+++ b/test/test/protojure/test/grpc/TestService/server.cljc
@@ -23,6 +23,7 @@
   (AsyncEmpty [this param])
   (Metadata [this param])
   (ReturnErrorStreaming [this param])
+  (AuthzTest [this param])
   (ShouldThrow [this param]))
 
 (def TestService-service-name "protojure.test.grpc.TestService")
@@ -63,6 +64,9 @@
 (defn- ReturnErrorStreaming-dispatch
   [ctx request]
   (ReturnErrorStreaming ctx request))
+(defn- AuthzTest-dispatch
+  [ctx request]
+  (AuthzTest ctx request))
 (defn- ShouldThrow-dispatch
   [ctx request]
   (ShouldThrow ctx request))
@@ -80,4 +84,5 @@
    {:pkg "protojure.test.grpc" :service "TestService" :method "AsyncEmpty" :method-fn AsyncEmpty-dispatch :server-streaming true :client-streaming false :input com.google.protobuf/pb->Empty :output com.google.protobuf/new-Empty}
    {:pkg "protojure.test.grpc" :service "TestService" :method "Metadata" :method-fn Metadata-dispatch :server-streaming false :client-streaming false :input com.google.protobuf/pb->Empty :output new-SimpleResponse}
    {:pkg "protojure.test.grpc" :service "TestService" :method "ReturnErrorStreaming" :method-fn ReturnErrorStreaming-dispatch :server-streaming true :client-streaming false :input pb->ErrorRequest :output com.google.protobuf/new-Empty}
+   {:pkg "protojure.test.grpc" :service "TestService" :method "AuthzTest" :method-fn AuthzTest-dispatch :server-streaming false :client-streaming false :input pb->AuthzTestRequest :output com.google.protobuf/new-Empty}
    {:pkg "protojure.test.grpc" :service "TestService" :method "ShouldThrow" :method-fn ShouldThrow-dispatch :server-streaming false :client-streaming false :input com.google.protobuf/pb->Empty :output com.google.protobuf/new-Empty}])

--- a/test/test/resources/grpctest.proto
+++ b/test/test/resources/grpctest.proto
@@ -44,6 +44,15 @@ message BigPayload {
     bytes data = 2;
 }
 
+message AuthzTestRequest {
+    enum Type {
+        REQUEST_GOOD = 0;
+        REQUEST_BAD  = 1;
+    }
+
+    Type type = 1;
+}
+
 service TestService {
     rpc ClientCloseDetect (CloseDetectRequest) returns (stream google.protobuf.Any);
     rpc ServerCloseDetect (google.protobuf.Empty) returns (stream google.protobuf.Any);
@@ -58,4 +67,5 @@ service TestService {
     rpc ReturnErrorStreaming(ErrorRequest) returns (stream google.protobuf.Empty);
     rpc BandwidthTest(BigPayload) returns (BigPayload);
     rpc BidirectionalStreamTest(stream SimpleRequest) returns (stream SimpleResponse);
+    rpc AuthzTest(AuthzTestRequest) returns (google.protobuf.Empty);
 }


### PR DESCRIPTION
This feature allows an optional authz predicate to be provided to the pedestal stack as an authz/interceptor slotted after the grpc-decode but before the grpc handler.  It operates identitically to any use of authz/interceptor, but has the advantage of having access to the GRPC input parameters.  This means that authz operations may factor in the specifics of a request, such as the resource being accessed.

Signed-off-by: Greg Haskins <greg@manetu.com>