### PR TITLE
grpc-client (jetty): Fix NPE in onIdleTimeout Session.Listener

### DIFF
--- a/modules/grpc-client/src/protojure/internal/grpc/client/providers/http2/jetty.clj
+++ b/modules/grpc-client/src/protojure/internal/grpc/client/providers/http2/jetty.clj
@@ -135,7 +135,9 @@
       (onIdleTimeout [_ stream ex]
         (stream-log :error stream "Timeout")
         (>!! meta-ch {:error {:type :timeout :error ex}})
-        (end-stream! stream))
+        (end-stream! stream)
+        ;; true: Close the session
+        true)
       (onClosed [_ stream]
         (stream-log :trace stream "Closed"))
       (onPush [_ stream frame]


### PR DESCRIPTION
The Http2Client Session.Listener.onIdleTimeout [returns a boolean](https://github.com/eclipse/jetty.project/blob/8cfed5543c98d0a65fdd76db7018286813d5ed7a/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/api/Session.java#L277) which indicates if the session should close after handling the timeout.

Return true from our handler, rather than nil.

Resolves #149 