### PR TITLE
Use case-insensitive regex instead of bulk-converting all headers to …

### DIFF
--- a/modules/core/project.clj
+++ b/modules/core/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.protojure/core "2.8.2-SNAPSHOT"
+(defproject io.github.protojure/core "2.9.0-SNAPSHOT"
   :description "Core protobuf and GRPC utilities for protojure"
   :url "http://github.com/protojure/lib"
   :license {:name "Apache License 2.0"

--- a/modules/grpc-client/project.clj
+++ b/modules/grpc-client/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.protojure/grpc-client "2.8.2-SNAPSHOT"
+(defproject io.github.protojure/grpc-client "2.9.0-SNAPSHOT"
   :description "GRPC client library for protoc-gen-clojure"
   :url "http://github.com/protojure/lib"
   :license {:name "Apache License 2.0"

--- a/modules/grpc-server/project.clj
+++ b/modules/grpc-server/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.protojure/grpc-server "2.8.2-SNAPSHOT"
+(defproject io.github.protojure/grpc-server "2.9.0-SNAPSHOT"
   :description "GRPC server library for protoc-gen-clojure"
   :url "http://github.com/protojure/lib"
   :license {:name "Apache License 2.0"

--- a/modules/grpc-server/src/protojure/pedestal/interceptors/grpc.clj
+++ b/modules/grpc-server/src/protojure/pedestal/interceptors/grpc.clj
@@ -12,10 +12,18 @@
             [io.pedestal.interceptor :as pedestal]
             [io.pedestal.interceptor.error :as err]
             [io.pedestal.log :as log]
-            [protojure.grpc.status :as grpc.status])
+            [protojure.grpc.status :as grpc.status]
+            [protojure.pedestal.utils :as u])
   (:import [java.util UUID]))
 
 (set! *warn-on-reflection* true)
+
+(def ^{:no-doc true :const true} grpc-encoding #"(?i)grpc-encoding")
+(def ^{:no-doc true :const true} grpc-accept-encoding #"(?i)grpc-accept-encoding")
+
+(defn- get-input-encoding [headers]
+  (or (u/get-header headers grpc-encoding)
+      "identity"))
 
 (def ^{:const true :no-doc true} supported-encodings (-> protojure.grpc.codec.compression/builtin-codecs (keys) (conj "identity") (set)))
 
@@ -25,23 +33,29 @@
        (filter supported-encodings)
        (first)))
 
+(defn- get-output-encoding [headers]
+  (or (some-> (u/get-header headers grpc-accept-encoding)
+              (determine-output-encoding))
+      "identity"))
+
 (defn logging-chan [bufsiz id label]
   (async/chan bufsiz (map (fn [m] (log/trace (str "GRPC: " id " -> " label) m) m))))
 
 (defn- create-req-ctx
-  [id f {:keys [body-ch] {:strs [grpc-encoding] :or {grpc-encoding "identity"}} :headers :as req}]
+  [id f {:keys [body-ch headers] :as req}]
   (let [in body-ch
-        out (logging-chan 128 id "rx")]
+        out (logging-chan 128 id "rx")
+        encoding (get-input-encoding headers)]
     {:in       in
      :out      out
-     :encoding grpc-encoding
-     :status   (lpm/decode f in out {:content-coding grpc-encoding})}))
+     :encoding encoding
+     :status   (lpm/decode f in out {:content-coding encoding})}))
 
 (defn- create-resp-ctx
-  [id f {{:strs [grpc-accept-encoding] :or {grpc-accept-encoding ""}} :headers :as req}]
+  [id f {:keys [headers] :as req}]
   (let [in (logging-chan 128 id "tx")
         out (async/chan 128)
-        encoding (or (determine-output-encoding grpc-accept-encoding) "identity")]
+        encoding (get-output-encoding headers)]
     {:in       in
      :out      out
      :encoding encoding

--- a/modules/grpc-server/src/protojure/pedestal/interceptors/grpc_web.clj
+++ b/modules/grpc-server/src/protojure/pedestal/interceptors/grpc_web.clj
@@ -20,7 +20,7 @@
     "application/grpc-web-text+proto"})
 
 (defn- web-text?
-  [{{:strs [content-type]} :headers}]
+  [{:keys [content-type]}]
   (contains? content-types content-type))
 
 (defn- pred->

--- a/modules/grpc-server/src/protojure/pedestal/utils.clj
+++ b/modules/grpc-server/src/protojure/pedestal/utils.clj
@@ -1,0 +1,7 @@
+;; Copyright © Manetu, Inc.  All rights reserved
+;;
+;; SPDX-License-Identifier: Apache-2.0
+(ns protojure.pedestal.utils)
+
+(defn get-header [headers re]
+  (some (fn [[k v]] (when (some? (re-matches re k)) v)) headers))

--- a/modules/io/project.clj
+++ b/modules/io/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.protojure/io "2.8.2-SNAPSHOT"
+(defproject io.github.protojure/io "2.9.0-SNAPSHOT"
   :description "IO library to support io.github.protojure/core"
   :url "http://github.com/protojure/lib"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def protojure-version "2.8.2-SNAPSHOT")
+(def protojure-version "2.9.0-SNAPSHOT")
 
 (defproject io.github.protojure/lib-suite "0.0.1"
   :description "Support libraries for protoc-gen-clojure, providing native Clojure support for Google Protocol Buffers and GRPC applications"


### PR DESCRIPTION
…lower-case

We added logic that converted all headers to lower-case to make finding certain headers, such as content-type and grpc-encoding, work in a case-insensitive manner.

However, this approach causes problems with case-sensitive headers like the X-B3 trace propagators.  This change removes the bulk conversion to lower-case in favor of broader case-insensitive pattern matching.

N.B.  This patch may be a breaking change if any applications built on Protojure's grpc-server relied on the header behavior.  As such, we will bump the version for this patch.