### PR TITLE
Revert "Use case-insensitive regex instead of bulk-converting all hea…

### DIFF
--- a/modules/core/project.clj
+++ b/modules/core/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.protojure/core "2.9.0-SNAPSHOT"
+(defproject io.github.protojure/core "2.8.2-SNAPSHOT"
   :description "Core protobuf and GRPC utilities for protojure"
   :url "http://github.com/protojure/lib"
   :license {:name "Apache License 2.0"

--- a/modules/grpc-client/project.clj
+++ b/modules/grpc-client/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.protojure/grpc-client "2.9.0-SNAPSHOT"
+(defproject io.github.protojure/grpc-client "2.8.2-SNAPSHOT"
   :description "GRPC client library for protoc-gen-clojure"
   :url "http://github.com/protojure/lib"
   :license {:name "Apache License 2.0"

--- a/modules/grpc-server/project.clj
+++ b/modules/grpc-server/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.protojure/grpc-server "2.9.0-SNAPSHOT"
+(defproject io.github.protojure/grpc-server "2.8.2-SNAPSHOT"
   :description "GRPC server library for protoc-gen-clojure"
   :url "http://github.com/protojure/lib"
   :license {:name "Apache License 2.0"

--- a/modules/grpc-server/src/protojure/pedestal/core.clj
+++ b/modules/grpc-server/src/protojure/pedestal/core.clj
@@ -10,11 +10,11 @@
             [io.pedestal.interceptor.helpers :as pedestal.interceptors]
             [io.pedestal.log :as log]
             [clojure.string :as string]
-            [clojure.core.async :refer [<!! <! go chan >!! close! poll! promise-chan]]
+            [clojure.pprint :refer [pprint]]
+            [clojure.core.async :refer [go-loop <!! <! go chan >!! >! close! timeout poll! promise-chan]]
             [promesa.core :as p]
             [clojure.java.io :as io]
             [protojure.pedestal.ssl :as ssl]
-            [protojure.pedestal.utils :as u]
             [protojure.internal.io :as pio])
   (:import (io.undertow.server HttpHandler
                                HttpServerExchange
@@ -40,7 +40,7 @@
 (defn- assoc-header
   "Associates an undertow header entry as a <string, string> tuple in a map"
   [^HeaderMap headers map ^HttpString key]
-  (assoc map (str key) (.get headers key 0)))
+  (assoc map (string/lower-case key) (.get headers key 0)))
 
 (defn- get-request-headers
   "Create a map of request header elements"
@@ -310,13 +310,10 @@
      (let [response-handler (pedestal.interceptors/on-response ::container resolve)]
        (pedestal.chain/execute {:request request} (cons response-handler interceptors))))))
 
-(def ^{:no-doc true :const true} content-type-re #"(?i)content-type")
-
 (defn- make-request-map [input-ch connections ^HttpServerExchange exchange]
   (let [input-stream (pio/new-inputstream {:ch input-ch})
         headers      (get-request-headers exchange)
-        ssl-cert     (get-ssl-client-cert exchange)
-        content-type (u/get-header headers content-type-re)]
+        ssl-cert     (get-ssl-client-cert exchange)]
     (cond-> {:query-string     (.getQueryString exchange)
              :request-method   (keyword (string/lower-case (.toString (.getRequestMethod exchange))))
              :headers          headers
@@ -335,8 +332,8 @@
              :server-port      (.getHostPort exchange)
              :scheme           (keyword (.getRequestScheme exchange))
              :async-supported? true}
-      (some? content-type)
-      (assoc :content-type content-type)
+      (contains? headers "content-type")
+      (assoc :content-type (get headers "content-type"))
 
       (not (neg? (.getRequestContentLength exchange)))
       (assoc :content-length (.getRequestContentLength exchange))

--- a/modules/grpc-server/src/protojure/pedestal/interceptors/grpc_web.clj
+++ b/modules/grpc-server/src/protojure/pedestal/interceptors/grpc_web.clj
@@ -20,7 +20,7 @@
     "application/grpc-web-text+proto"})
 
 (defn- web-text?
-  [{:keys [content-type]}]
+  [{{:strs [content-type]} :headers}]
   (contains? content-types content-type))
 
 (defn- pred->

--- a/modules/grpc-server/src/protojure/pedestal/utils.clj
+++ b/modules/grpc-server/src/protojure/pedestal/utils.clj
@@ -1,7 +1,0 @@
-;; Copyright © Manetu, Inc.  All rights reserved
-;;
-;; SPDX-License-Identifier: Apache-2.0
-(ns protojure.pedestal.utils)
-
-(defn get-header [headers re]
-  (some (fn [[k v]] (when (some? (re-matches re k)) v)) headers))

--- a/modules/io/project.clj
+++ b/modules/io/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.protojure/io "2.9.0-SNAPSHOT"
+(defproject io.github.protojure/io "2.8.2-SNAPSHOT"
   :description "IO library to support io.github.protojure/core"
   :url "http://github.com/protojure/lib"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def protojure-version "2.9.0-SNAPSHOT")
+(def protojure-version "2.8.2-SNAPSHOT")
 
 (defproject io.github.protojure/lib-suite "0.0.1"
   :description "Support libraries for protoc-gen-clojure, providing native Clojure support for Google Protocol Buffers and GRPC applications"


### PR DESCRIPTION
…ders to lower-case"

This reverts commit f7952c18ca4860366dda9605d80bbb4b1e28fb1b.

I misinterpretted an error somewhere else when I concluded this was the right fix.  Upon further reflection, I think this was the wrong fix.  So reverting it for now.  We can always revisit it later.

Signed-off-by: Greg Haskins <greg@manetu.com>