### PR TITLE
Remove core.async go-routines from LPM flow

### DIFF
--- a/modules/grpc-client/src/protojure/internal/grpc/client/providers/http2/core.clj
+++ b/modules/grpc-client/src/protojure/internal/grpc/client/providers/http2/core.clj
@@ -4,13 +4,12 @@
 ;; SPDX-License-Identifier: Apache-2.0
 
 (ns protojure.internal.grpc.client.providers.http2.core
-  (:require [clojure.core.async :refer [>!! <!! <! >! go go-loop onto-chan] :as async]
+  (:require [clojure.core.async :refer [<! go-loop] :as async]
             [clojure.tools.logging :as log]
             [protojure.grpc.client.api :as api]
             [protojure.grpc.codec.lpm :as lpm]
             [protojure.internal.grpc.client.providers.http2.jetty :as jetty]
-            [promesa.core :as p]
-            [promesa.exec :as exec])
+            [promesa.core :as p])
   (:import (org.eclipse.jetty.http2.api Stream)
            (java.util.concurrent Executors))
   (:refer-clojure :exclude [resolve]))

--- a/modules/grpc-server/src/protojure/pedestal/core.clj
+++ b/modules/grpc-server/src/protojure/pedestal/core.clj
@@ -10,8 +10,7 @@
             [io.pedestal.interceptor.helpers :as pedestal.interceptors]
             [io.pedestal.log :as log]
             [clojure.string :as string]
-            [clojure.pprint :refer [pprint]]
-            [clojure.core.async :refer [go-loop <!! <! go chan >!! >! close! timeout poll! promise-chan]]
+            [clojure.core.async :refer [<!! <! go chan >!! close! poll! promise-chan]]
             [promesa.core :as p]
             [promesa.exec :as p.exec]
             [clojure.java.io :as io]
@@ -31,7 +30,6 @@
            (io.undertow.io Receiver$PartialBytesCallback Receiver$ErrorCallback)
            (java.nio ByteBuffer)
            (org.xnio.channels StreamSinkChannel)
-           (java.util.concurrent Executors ThreadPoolExecutor)
            (clojure.lang IPersistentCollection IFn)
            (java.time LocalTime))
   (:refer-clojure :exclude [resolve flush]))

--- a/modules/grpc-server/src/protojure/pedestal/interceptors/grpc.clj
+++ b/modules/grpc-server/src/protojure/pedestal/interceptors/grpc.clj
@@ -5,7 +5,7 @@
 
 (ns protojure.pedestal.interceptors.grpc
   "A [Pedestal](http://pedestal.io/) [interceptor](http://pedestal.io/reference/interceptors) for [GRPC](https://grpc.io/) support"
-  (:require [clojure.core.async :refer [go >! <!] :as async]
+  (:require [clojure.core.async :refer [go <!] :as async]
             [protojure.grpc.codec.lpm :as lpm]
             [protojure.grpc.status :as status]
             [promesa.core :as p]

--- a/modules/io/src/protojure/internal/io.clj
+++ b/modules/io/src/protojure/internal/io.clj
@@ -4,7 +4,7 @@
 ;; SPDX-License-Identifier: Apache-2.0
 
 (ns ^:no-doc protojure.internal.io
-  (:require [clojure.core.async :refer [<! >! <!! alt!! go go-loop] :as async])
+  (:require [clojure.core.async :refer [<!! alt!!] :as async])
   (:import (java.nio ByteBuffer)
            (protojure.internal.io ProxyInputStream AsyncInputStream
                                   ProxyOutputStream AsyncOutputStream)))

--- a/test/test/protojure/iostream_test.clj
+++ b/test/test/protojure/iostream_test.clj
@@ -34,7 +34,12 @@
   (testing "Verify that our input stream's timeout mechanism works"
     (let [input (async/chan 64)
           stream (pio/new-inputstream {:ch input :tmo 100})]
-      (is (thrown? clojure.lang.ExceptionInfo (.read stream))))))
+      (is (thrown? clojure.lang.ExceptionInfo (.read stream)))))
+  (testing "Verify that our input stream's timeout mechanism works"
+    (let [input (async/chan 64)
+          stream (pio/new-inputstream {:ch input :tmo 10000})]
+      (async/close! input)
+      (is (= (.read stream) -1)))))
 
 (deftest check-array-read
   (testing "Verify that we can read an array in one call"


### PR DESCRIPTION
It is possible for the LPM flow to block, thus making it incompatible with the use of go-routines.  We re-tool LPM to use vthreads (when available) which should offer a similar resource consumption model as core.async but without the limitations of blocking.  Users on < JDK21 will gracefully degrade to a standard platform thread, which isn't great but its also more correct than leaving LPM using core.async incorrectly.