### PR TITLE
chore: bump to v2.12.0-SNAPSHOT and update dependencies

### DIFF
--- a/modules/core/project.clj
+++ b/modules/core/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.protojure/core "2.11.1-SNAPSHOT"
+(defproject io.github.protojure/core "2.12.0-SNAPSHOT"
   :description "Core protobuf and GRPC utilities for protojure"
   :url "http://github.com/protojure/lib"
   :license {:name "Apache License 2.0"

--- a/modules/core/src/protojure/grpc/codec/lpm.clj
+++ b/modules/core/src/protojure/grpc/codec/lpm.clj
@@ -7,10 +7,10 @@
   "Utility functions for GRPC [length-prefixed-message](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#requests) encoding."
   (:require [clojure.core.async :refer [<!! >!!] :as async]
             [promesa.core :as p]
-            [promesa.exec :as p.exec]
             [protojure.protobuf :refer [->pb]]
             [protojure.grpc.codec.compression :as compression]
             [protojure.internal.io :as pio]
+            [protojure.threads :as threads]
             [clojure.tools.logging :as log]
             [clojure.java.io :as io])
   (:import (java.io InputStream OutputStream ByteArrayOutputStream)
@@ -19,7 +19,7 @@
 
 (set! *warn-on-reflection* true)
 
-(def lpm-thread-executor (if p.exec/vthreads-supported? p.exec/vthread-executor p.exec/thread-executor))
+(def lpm-thread-executor (threads/get-executor))
 
 ;;--------------------------------------------------------------------------------------
 ;; integer serdes used for GRPC framing

--- a/modules/core/src/protojure/threads.clj
+++ b/modules/core/src/protojure/threads.clj
@@ -1,0 +1,9 @@
+;; Copyright © 2026 Manetu, Inc.  All rights reserved
+;;
+;; SPDX-License-Identifier: Apache-2.0
+
+(ns protojure.threads
+  (:require [promesa.exec :as p.exec]))
+
+(defn get-executor []
+  (if p.exec/virtual-threads-available? p.exec/default-vthread-executor p.exec/default-thread-executor))

--- a/modules/grpc-client/project.clj
+++ b/modules/grpc-client/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.protojure/grpc-client "2.11.1-SNAPSHOT"
+(defproject io.github.protojure/grpc-client "2.12.0-SNAPSHOT"
   :description "GRPC client library for protoc-gen-clojure"
   :url "http://github.com/protojure/lib"
   :license {:name "Apache License 2.0"

--- a/modules/grpc-server/project.clj
+++ b/modules/grpc-server/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.protojure/grpc-server "2.11.1-SNAPSHOT"
+(defproject io.github.protojure/grpc-server "2.12.0-SNAPSHOT"
   :description "GRPC server library for protoc-gen-clojure"
   :url "http://github.com/protojure/lib"
   :license {:name "Apache License 2.0"

--- a/modules/grpc-server/src/protojure/pedestal/core.clj
+++ b/modules/grpc-server/src/protojure/pedestal/core.clj
@@ -15,7 +15,8 @@
             [promesa.exec :as p.exec]
             [clojure.java.io :as io]
             [protojure.pedestal.ssl :as ssl]
-            [protojure.internal.io :as pio])
+            [protojure.internal.io :as pio]
+            [protojure.threads :as threads])
   (:import (io.undertow.server HttpHandler
                                HttpServerExchange
                                ServerConnection
@@ -394,7 +395,7 @@
   "Generates our undertow provider, which defines the callback point between
   the undertow container and pedestal by dealing with the dispatch interop.
   Our real work occurs in the (request) form above"
-  [{:keys [::thread-pool] :or {thread-pool (if p.exec/vthreads-supported? p.exec/vthread-executor p.exec/thread-executor)} :as service-map}]
+  [{:keys [::thread-pool] :or {thread-pool (threads/get-executor)} :as service-map}]
   (let [interceptors (::http/interceptors service-map)
         connections (atom {})]
     (assoc service-map ::handler

--- a/modules/io/project.clj
+++ b/modules/io/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.protojure/io "2.11.1-SNAPSHOT"
+(defproject io.github.protojure/io "2.12.0-SNAPSHOT"
   :description "IO library to support io.github.protojure/core"
   :url "http://github.com/protojure/lib"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def protojure-version "2.11.1-SNAPSHOT")
+(def protojure-version "2.12.0-SNAPSHOT")
 
 (defproject io.github.protojure/lib-suite "0.0.1"
   :description "Support libraries for protoc-gen-clojure, providing native Clojure support for Google Protocol Buffers and GRPC applications"
@@ -9,21 +9,21 @@
             :key "apache-2.0"}
   :plugins [[lein-set-version "0.4.1"]
             [lein-sub "0.3.0"]]
-  :managed-dependencies [[org.clojure/clojure "1.12.0"]
-                         [org.clojure/core.async "1.6.681"]
-                         [org.clojure/tools.logging "1.3.0"]
-                         [com.google.protobuf/protobuf-java "4.28.0"]
-                         [org.apache.commons/commons-compress "1.27.1"]
-                         [commons-io/commons-io "2.16.1"]
-                         [funcool/promesa "9.2.542"]
+  :managed-dependencies [[org.clojure/clojure "1.12.4"]
+                         [org.clojure/core.async "1.9.865"]
+                         [org.clojure/tools.logging "1.3.1"]
+                         [com.google.protobuf/protobuf-java "4.34.1"]
+                         [org.apache.commons/commons-compress "1.28.0"]
+                         [commons-io/commons-io "2.21.0"]
+                         [funcool/promesa "11.0.678"]
                          [javax.servlet/javax.servlet-api "4.0.1"]
-                         [io.undertow/undertow-core "2.3.17.Final"]
-                         [io.undertow/undertow-servlet "2.3.17.Final"]
-                         [io.pedestal/pedestal.log "0.7.0"]
-                         [io.pedestal/pedestal.service "0.7.0"]
-                         [io.pedestal/pedestal.error "0.7.0"]
-                         [org.eclipse.jetty.http2/http2-client "11.0.24"]
-                         [org.eclipse.jetty/jetty-alpn-java-client "12.0.13"]
+                         [io.undertow/undertow-core "2.3.24.Final"]
+                         [io.undertow/undertow-servlet "2.3.24.Final"]
+                         [io.pedestal/pedestal.log "0.7.2"]
+                         [io.pedestal/pedestal.service "0.7.2"]
+                         [io.pedestal/pedestal.error "0.7.2"]
+                         [org.eclipse.jetty.http2/http2-client "11.0.26"]
+                         [org.eclipse.jetty/jetty-alpn-java-client "12.1.8"]
                          [lambdaisland/uri "1.19.155"]
                          [io.github.protojure/io ~protojure-version]
                          [io.github.protojure/core ~protojure-version]


### PR DESCRIPTION
Introduce protojure.threads/get-executor to consolidate virtual-thread detection logic, replacing duplicated inline checks in lpm.clj and pedestal/core.clj.

Update managed-dependencies to latest stable versions:
- clojure 1.12.4, core.async 1.9.865, tools.logging 1.3.1
- protobuf-java 4.34.1, commons-compress 1.28.0, commons-io 2.21.0
- promesa 11.0.678, undertow 2.3.24.Final, pedestal 0.7.2
- jetty http2-client 11.0.26, jetty-alpn-java-client 12.1.8