### PR TITLE
feat: upgrade shaded Jetty from 11.0.26 to 12.1.8

### DIFF
--- a/modules/grpc-client/src/protojure/internal/grpc/client/providers/http2/jetty.clj
+++ b/modules/grpc-client/src/protojure/internal/grpc/client/providers/http2/jetty.clj
@@ -14,9 +14,9 @@
            (io.github.protojure.shaded.jetty.http2.client HTTP2Client)
            (io.github.protojure.shaded.jetty.http2.api Stream$Listener
                                                        Stream
+                                                       Stream$Data
                                                        Session
-                                                       Session$Listener
-                                                       Session$Listener$Adapter)
+                                                       Session$Listener)
            (io.github.protojure.shaded.jetty.http2.frames HeadersFrame
                                                           DataFrame)
            (io.github.protojure.shaded.jetty.util Promise Callback)
@@ -99,7 +99,7 @@
     (reify Stream$Listener
       (onHeaders [_ stream frame]
         (let [^MetaData metadata (.getMetaData ^HeadersFrame frame)
-              fields (fields-> (.getFields metadata))
+              fields (fields-> (.getHttpFields metadata))
               data (if (.isResponse metadata)
                      (let [status (.getStatus ^MetaData$Response metadata)
                            reason (.getReason ^MetaData$Response metadata)]
@@ -110,36 +110,42 @@
               last? (.isEndStream ^HeadersFrame frame)]
           (stream-log :trace stream "Received HEADER-FRAME: " data " ENDFRAME=" last?)
           (>!! meta-ch data)
-          (when last?
-            (end-stream! stream))))
-      (onData [_ stream frame callback]
-        (let [data (.getData ^DataFrame frame)
-              len (.remaining data)
-              last? (.isEndStream ^DataFrame frame)]
-          (stream-log :trace stream "Received DATA-FRAME (" len " bytes) ENDFRAME=" last?)
-          (when (and (some? data-ch) (pos? len))
-            (let [clone (ByteBuffer/allocate len)]
-              (.put clone data)
-              (async/>!! data-ch (.flip clone))))
-          (when last?
-            (end-stream! stream))
-          (.succeeded callback)))
+          (if last?
+            (end-stream! stream)
+            (.demand stream))))
+      (onDataAvailable [_ stream]
+        (loop []
+          (when-let [^Stream$Data sd (.readData stream)]
+            (let [^DataFrame frame (.frame sd)
+                  data (.getByteBuffer frame)
+                  len (.remaining data)
+                  last? (.isEndStream frame)]
+              (stream-log :trace stream "Received DATA-FRAME (" len " bytes) ENDFRAME=" last?)
+              (when (and (some? data-ch) (pos? len))
+                (let [clone (ByteBuffer/allocate len)]
+                  (.put clone data)
+                  (async/>!! data-ch (.flip clone))))
+              (.release sd)
+              (if last?
+                (end-stream! stream)
+                (do (.demand stream) (recur)))))))
       (onFailure [_ stream error reason ex callback]
         (stream-log :error stream "FAILURE: code-> " error " message-> " (ex-message ex))
         (>!! meta-ch {:error {:type :failure :code error :reason reason :ex ex}})
         (end-stream! stream)
         (.succeeded callback))
-      (onReset [_ stream frame]
+      (onReset [_ stream frame callback]
         (stream-log :error stream "Received RST-FRAME")
         (let [error (.getError frame)]
           (>!! meta-ch {:error {:type :reset :code error}})
-          (end-stream! stream)))
-      (onIdleTimeout [_ stream ex]
+          (end-stream! stream)
+          (.succeeded callback)))
+      (onIdleTimeout [_ stream ex promise]
         (stream-log :error stream "Timeout")
         (>!! meta-ch {:error {:type :timeout :error ex}})
         (end-stream! stream)
         ;; true: Close the session
-        true)
+        (.succeeded promise true))
       (onClosed [_ stream]
         (stream-log :trace stream "Closed"))
       (onPush [_ stream frame]
@@ -182,24 +188,29 @@
     (p/resolved true)))
 
 (defn- session-listener
-  "Create a listener for Session events"
+  "Create a listener for Session events.
+  Proxy is used rather than reify to avoid cloverage instrumentation issues with
+  interface default methods; all methods must be implemented explicitly."
   [on-close]
-  (if (some? on-close)
-    (let [go-away-once (AtomicBoolean. false)]
-      (proxy [Session$Listener$Adapter] []
-        ;; We must re-implement a bit of logic from the base class here to invoke callback.
-        ;; See https://github.com/jetty/jetty.project/blob/5bc5e562c8d05c5862505aebe5cf83a61bdbcb96/jetty-http2/http2-common/src/main/java/org/eclipse/jetty/http2/api/Session.java#L256
-        (onClose [_session _frame ^Callback callback]
-          (try
-            (when (.compareAndSet go-away-once false true)
-              ;; An HTTP/2 session may send multiple GOAWAY frames on disconnect.
-              ;; Trigger on-close once, upon the first frame.
-              ;; https://datatracker.ietf.org/doc/html/rfc7540#section-6.8
-              (on-close))
-            (.succeeded callback)
-            (catch Throwable e
-              (.failed callback e))))))
-    (Session$Listener$Adapter.)))
+  (let [go-away-once (AtomicBoolean. false)]
+    (proxy [Session$Listener] []
+      (onPreface [_] nil)
+      (onNewStream [_ _] nil)
+      (onSettings [_ _])
+      (onPing [_ _])
+      (onReset [_ _])
+      (onGoAway [_ _])
+      ;; Multiple GOAWAY frames are possible (RFC 7540 §6.8). Trigger on-close once.
+      ;; https://datatracker.ietf.org/doc/html/rfc7540#section-6.8
+      (onClose [_ _ ^Callback callback]
+        (try
+          (when (and on-close (.compareAndSet go-away-once false true))
+            (on-close))
+          (.succeeded callback)
+          (catch Throwable e
+            (.failed callback e))))
+      (onIdleTimeout [_] true)
+      (onFailure [_ _ ^Callback callback] (.succeeded callback)))))
 
 ;;------------------------------------------------------------------------------------
 ;; Exposed API

--- a/modules/jetty-shaded/pom.xml
+++ b/modules/jetty-shaded/pom.xml
@@ -47,8 +47,8 @@
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty.http2</groupId>
-      <artifactId>http2-client</artifactId>
-      <version>11.0.26</version>
+      <artifactId>jetty-http2-client</artifactId>
+      <version>12.1.8</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
                          [io.github.protojure/grpc-client ~protojure-version]
                          [io.github.protojure/grpc-server ~protojure-version]
                          [protojure/google.protobuf "1.0.0"]]
-  :javac-options ["-target" "11" "-source" "11"]
+  :javac-options ["--release" "17"]
   :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
                                     :username :env/clojars_username
                                     :password :env/clojars_password

--- a/test/project.clj
+++ b/test/project.clj
@@ -48,4 +48,4 @@
   :cloverage {:runner :eftest
               :runner-opts {:multithread? false
                             :fail-fast? true}
-              :fail-threshold 81})
+              :fail-threshold 83})


### PR DESCRIPTION
Jetty 12 is a major release with a minimum Java 17 requirement and several HTTP/2 client API breaking changes. This commit migrates to the new API while preserving all 80 existing tests (0 failures, 83.99% coverage, above the 81% threshold).

Changes:
- modules/jetty-shaded/pom.xml: rename artifact http2-client → jetty-http2-client and align both deps to 12.1.8
- project.clj: javac-options -source/-target 11 → --release 17
- jetty.clj: migrate six breaking API changes:
  * MetaData.getFields() → getHttpFields()
  * DataFrame.getData() → getByteBuffer()
  * Stream.Listener.onData push-model → onDataAvailable pull-model (stream.readData() + stream.demand() + data.release())
  * onReset and onIdleTimeout new signatures
  * Session.Listener.Adapter removed; replaced with proxy implementing all nine Session.Listener methods explicitly (proxy required over reify due to cloverage instrumentation limitations with default interface methods)